### PR TITLE
Protocol error handling refactor

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -86,22 +86,14 @@ impl StreamToClient {
 
     pub fn send_message(&mut self, msg: ServerMessage) -> Result<(), ProtocolError> {
         let encoded_msg = encode_server_msg(msg)?;
-        match self.stream.write_all(&encoded_msg) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let msg = format!("{}", e);
-                Err( ProtocolError { msg } )
-            },
-        }
+        self.stream.write_all(&encoded_msg)?;
+        Ok(())
     }
 
     pub fn recv_message(&mut self) -> Result<ClientMessage, ProtocolError> {
         let mut buffer = Vec::<u8>::with_capacity(1);
 
-        if let Err(e) = self.stream.read_exact(&mut buffer) {
-            let msg = format!("{}", e);
-            return Err( ProtocolError { msg } );
-        }
+        self.stream.read_exact(&mut buffer)? 
 
         // Should never panic
         let msg_byte = char::from(buffer.pop().unwrap());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -93,7 +93,7 @@ impl StreamToClient {
     pub fn recv_message(&mut self) -> Result<ClientMessage, ProtocolError> {
         let mut buffer = Vec::<u8>::with_capacity(1);
 
-        self.stream.read_exact(&mut buffer)? 
+        self.stream.read_exact(&mut buffer)?;
 
         // Should never panic
         let msg_byte = char::from(buffer.pop().unwrap());


### PR DESCRIPTION
Uso el [operador `?`](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator) para reducir la identación y mejorar la legibilidad.

En resumen, el `?` en caso de error salta a un `Err()` implicito. Caso contrario continúa. Esto nos ahorra el pattern matching en cada una de las validaciones de error.

Por otro lado, implementamos los treats para los tipos de error que estamos manejando para que este `Err() implícito` del que hablaba forme el mensaje correctamente.

O sea, el funcionamiento es el mismo. Me falta ver como generalizar estos errores para no tener que repetir el código con cada tipo, además de abarcar un abanico más amplio.

```rs
impl From<str::Utf8Error> for ProtocolError {
    fn from(err: str::Utf8Error) -> Self {
        ProtocolError { msg: format!("{}", err) }
    }
}

impl From<ParseIntError> for ProtocolError {
    fn from(err: ParseIntError) -> Self {
        ProtocolError { msg: format!("{}", err) }
    }
}

impl From<std::io::Error> for ProtocolError {
    fn from(err: std::io::Error) -> Self {
        ProtocolError { msg: format!("{}", err) }
    }
}
```

De todas formas, el *cargo build* muestra los errores mal manejados con el operador `?`, por lo que todos los casos están cubiertos.